### PR TITLE
replaces url for get-openscad.sh because prior url is a 404.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,19 @@ build an editor for OpenSCAD that is capable of loading `.scad` files from other
 
 # Dev
 
+## Download openscad-wasm
+
+```bash
+cd scripts
+./get-openscad.sh
+```
+
+If that fails, you will want to go to https://files.openscad.org/playground/.  There should be two versions of openscad-wasm.  You want -web not -node.
+
+Once you have that url, you can alter get-openscad.sh to change it and run again.
+
+## Start the server in dev mode
+
 ```bash
 git clone https://github.com/seasick/openscad-web-gui
 npm i

--- a/scripts/get-openscad.sh
+++ b/scripts/get-openscad.sh
@@ -3,7 +3,7 @@
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 DIST_DIR=$SCRIPT_DIR/../dist
 VENDOR_DIR=$SCRIPT_DIR/../src/vendor/openscad-wasm
-OPENSCAD_WASM_URL=https://files.openscad.org/playground/OpenSCAD-2023.08.13.wasm16037-WebAssembly.zip
+OPENSCAD_WASM_URL=https://files.openscad.org/playground/OpenSCAD-2025.03.25.wasm24456-WebAssembly-web.zip
 
 mkdir -p $VENDOR_DIR
 mkdir -p $DIST_DIR


### PR DESCRIPTION
Fixed the broken url for openscad-wasm